### PR TITLE
Complete SSH auto-restore with secure password storage

### DIFF
--- a/mobile-vibe-terminal/src/androidMain/kotlin/tokyo/isseikuzumaki/vibeterminal/di/PlatformModule.kt
+++ b/mobile-vibe-terminal/src/androidMain/kotlin/tokyo/isseikuzumaki/vibeterminal/di/PlatformModule.kt
@@ -12,6 +12,7 @@ import tokyo.isseikuzumaki.vibeterminal.domain.installer.ApkInstaller
 import tokyo.isseikuzumaki.vibeterminal.domain.repository.ConnectionRepository
 import tokyo.isseikuzumaki.vibeterminal.domain.repository.SshRepository
 import tokyo.isseikuzumaki.vibeterminal.installer.AndroidApkInstaller
+import tokyo.isseikuzumaki.vibeterminal.security.PasswordEncryptionHelper
 import tokyo.isseikuzumaki.vibeterminal.ssh.MinaSshdRepository
 
 actual fun platformModule() = module {
@@ -25,6 +26,8 @@ actual fun platformModule() = module {
         createDataStore(context)
     }
 
+    single { PasswordEncryptionHelper() }
+
     factory<SshRepository> { MinaSshdRepository() }
 
     factory<ApkInstaller> {
@@ -35,6 +38,7 @@ actual fun platformModule() = module {
     factory<ConnectionRepository> {
         val database = get<AppDatabase>()
         val dataStore = get<DataStore<Preferences>>()
-        ConnectionRepositoryImpl(database.serverConnectionDao(), dataStore)
+        val passwordEncryption = get<PasswordEncryptionHelper>()
+        ConnectionRepositoryImpl(database.serverConnectionDao(), dataStore, passwordEncryption)
     }
 }

--- a/mobile-vibe-terminal/src/androidMain/kotlin/tokyo/isseikuzumaki/vibeterminal/security/PasswordEncryptionHelper.kt
+++ b/mobile-vibe-terminal/src/androidMain/kotlin/tokyo/isseikuzumaki/vibeterminal/security/PasswordEncryptionHelper.kt
@@ -1,0 +1,104 @@
+package tokyo.isseikuzumaki.vibeterminal.security
+
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import java.security.KeyStore
+import javax.crypto.Cipher
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+import javax.crypto.spec.GCMParameterSpec
+import android.util.Base64
+
+/**
+ * Helper class for encrypting and decrypting passwords using Android Keystore.
+ * Uses AES/GCM/NoPadding for secure encryption.
+ */
+class PasswordEncryptionHelper {
+    private val keyStore: KeyStore = KeyStore.getInstance("AndroidKeyStore").apply {
+        load(null)
+    }
+
+    companion object {
+        private const val KEY_ALIAS = "vibe_terminal_password_key"
+        private const val TRANSFORMATION = "AES/GCM/NoPadding"
+        private const val GCM_TAG_LENGTH = 128
+    }
+
+    /**
+     * Encrypts a password and returns the encrypted data as a Base64-encoded string.
+     * Format: "iv:encryptedData" where both are Base64-encoded.
+     */
+    fun encryptPassword(password: String): String {
+        val cipher = Cipher.getInstance(TRANSFORMATION)
+        cipher.init(Cipher.ENCRYPT_MODE, getOrCreateSecretKey())
+
+        val encryptedBytes = cipher.doFinal(password.toByteArray(Charsets.UTF_8))
+        val iv = cipher.iv
+
+        // Combine IV and encrypted data, separated by colon
+        val ivBase64 = Base64.encodeToString(iv, Base64.NO_WRAP)
+        val encryptedBase64 = Base64.encodeToString(encryptedBytes, Base64.NO_WRAP)
+
+        return "$ivBase64:$encryptedBase64"
+    }
+
+    /**
+     * Decrypts a Base64-encoded encrypted password string.
+     * Expects format: "iv:encryptedData"
+     */
+    fun decryptPassword(encryptedData: String): String {
+        val parts = encryptedData.split(":")
+        if (parts.size != 2) {
+            throw IllegalArgumentException("Invalid encrypted data format")
+        }
+
+        val iv = Base64.decode(parts[0], Base64.NO_WRAP)
+        val encryptedBytes = Base64.decode(parts[1], Base64.NO_WRAP)
+
+        val cipher = Cipher.getInstance(TRANSFORMATION)
+        val spec = GCMParameterSpec(GCM_TAG_LENGTH, iv)
+        cipher.init(Cipher.DECRYPT_MODE, getOrCreateSecretKey(), spec)
+
+        val decryptedBytes = cipher.doFinal(encryptedBytes)
+        return String(decryptedBytes, Charsets.UTF_8)
+    }
+
+    /**
+     * Gets the existing secret key or creates a new one if it doesn't exist.
+     */
+    private fun getOrCreateSecretKey(): SecretKey {
+        // Check if key already exists
+        keyStore.getKey(KEY_ALIAS, null)?.let {
+            return it as SecretKey
+        }
+
+        // Create new key
+        val keyGenerator = KeyGenerator.getInstance(
+            KeyProperties.KEY_ALGORITHM_AES,
+            "AndroidKeyStore"
+        )
+
+        val keyGenParameterSpec = KeyGenParameterSpec.Builder(
+            KEY_ALIAS,
+            KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
+        )
+            .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+            .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+            .setUserAuthenticationRequired(false)
+            .setRandomizedEncryptionRequired(true)
+            .build()
+
+        keyGenerator.init(keyGenParameterSpec)
+        return keyGenerator.generateKey()
+    }
+
+    /**
+     * Deletes the encryption key from the keystore.
+     * This will make all previously encrypted passwords unrecoverable.
+     */
+    fun deleteKey() {
+        if (keyStore.containsAlias(KEY_ALIAS)) {
+            keyStore.deleteEntry(KEY_ALIAS)
+        }
+    }
+}

--- a/mobile-vibe-terminal/src/commonMain/kotlin/tokyo/isseikuzumaki/vibeterminal/domain/repository/ConnectionRepository.kt
+++ b/mobile-vibe-terminal/src/commonMain/kotlin/tokyo/isseikuzumaki/vibeterminal/domain/repository/ConnectionRepository.kt
@@ -47,4 +47,20 @@ interface ConnectionRepository {
      * Set the last active connection ID for auto-restore
      */
     suspend fun setLastActiveConnectionId(connectionId: Long?)
+
+    /**
+     * Save encrypted password for a connection
+     */
+    suspend fun savePassword(connectionId: Long, password: String)
+
+    /**
+     * Get decrypted password for a connection
+     * @return the password, or null if not saved
+     */
+    suspend fun getPassword(connectionId: Long): String?
+
+    /**
+     * Delete saved password for a connection
+     */
+    suspend fun deletePassword(connectionId: Long)
 }

--- a/mobile-vibe-terminal/src/commonMain/kotlin/tokyo/isseikuzumaki/vibeterminal/ui/screens/TerminalScreen.kt
+++ b/mobile-vibe-terminal/src/commonMain/kotlin/tokyo/isseikuzumaki/vibeterminal/ui/screens/TerminalScreen.kt
@@ -59,8 +59,9 @@ data class TerminalScreen(
                     },
                     navigationIcon = {
                         IconButton(onClick = {
-                            screenModel.disconnect()
-                            navigator.pop()
+                            screenModel.disconnectAndClearSession {
+                                navigator.pop()
+                            }
                         }) {
                             Icon(Icons.AutoMirrored.Filled.ArrowBack, "Back")
                         }

--- a/mobile-vibe-terminal/src/iosMain/kotlin/tokyo/isseikuzumaki/vibeterminal/data/repository/ConnectionRepositoryStub.kt
+++ b/mobile-vibe-terminal/src/iosMain/kotlin/tokyo/isseikuzumaki/vibeterminal/data/repository/ConnectionRepositoryStub.kt
@@ -14,4 +14,7 @@ class ConnectionRepositoryStub : ConnectionRepository {
     override suspend fun updateLastUsed(connectionId: Long) {}
     override suspend fun getLastActiveConnectionId(): Long? = null
     override suspend fun setLastActiveConnectionId(connectionId: Long?) {}
+    override suspend fun savePassword(connectionId: Long, password: String) {}
+    override suspend fun getPassword(connectionId: Long): String? = null
+    override suspend fun deletePassword(connectionId: Long) {}
 }


### PR DESCRIPTION
## Summary

SSH Auto-Restore機能の完全版を実装しました。セキュアなパスワード保存により、アプリ再起動時に完全に自動化された接続復帰が可能になります。

### Phase 1: 基本的な自動復帰機能
- SSH接続の自動再接続機能
- 起動時コマンドのサポート（tmux、screen、byobuなどのプリセット付き）
- 前回アクティブだった接続の追跡
- データベーススキーマのマイグレーション（v2 → v3）

### Phase 2: セキュアなパスワード保存（今回追加）
- **Android Keystore統合**: AES/GCM/NoPadding暗号化によるパスワード保護
- **パスワード保存UI**: "Remember password (stored securely)" チェックボックス
- **シームレスな自動復帰**: 条件を満たせば直接TerminalScreenに遷移
- **適切な切断フロー**: 戻るボタンでlast IDをクリアしてから画面遷移

## 主な変更内容

### セキュリティレイヤー
- `PasswordEncryptionHelper`: Android Keystoreを使用した暗号化ヘルパー
  - AES/GCM/NoPadding暗号化
  - IV付きBase64エンコード
  - 安全な鍵管理

### データレイヤー
- `ConnectionRepository`に以下のメソッドを追加:
  - `savePassword(connectionId, password)`: 暗号化してDataStoreに保存
  - `getPassword(connectionId)`: 復号して取得
  - `deletePassword(connectionId)`: 削除
- `ConnectionRepositoryImpl`にPasswordEncryptionHelperを注入

### ドメイン/UIレイヤー
- `ConnectionListScreenModel`:
  - `checkAndRestoreLastSession()`: 起動時の自動復帰チェック
  - `loadPassword()`, `savePassword()`, `deletePassword()`: パスワード管理
- `TerminalScreenModel`:
  - `disconnectAndClearSession()`: 適切な順序で切断とクリア
- `ConnectionListScreen`:
  - 起動時の`LaunchedEffect`で自動復帰チェック
  - パスワード自動読み込み
- `PasswordDialog`:
  - "Remember password" チェックボックス追加
  - パスワード保存/削除のロジック

## 動作フロー

### 自動復帰が有効な場合
1. アプリ起動
2. `checkAndRestoreLastSession()` 実行
3. 条件チェック:
   - ✓ last active connection IDが存在
   - ✓ `isAutoReconnect = true`
   - ✓ パスワードが保存されている
4. **ConnectionListをスキップして直接TerminalScreenに遷移**
5. 起動コマンド（tmux attach等）を自動実行

### 明示的な切断の場合
1. ターミナル画面で戻るボタンをタップ
2. `disconnectAndClearSession()` 実行:
   - a. `setLastActiveConnectionId(null)` ← **先にクリア**
   - b. SSH切断
   - c. `navigator.pop()` で画面遷移
3. 次回起動時はConnectionListから開始

## セキュリティ対策

- パスワードは平文で保存されない
- Android Keystoreのハードウェア保護を利用
- 暗号化キーはアプリ外からアクセス不可
- 復号化失敗時は安全にnullを返す

## テスト計画

- [x] パスワード保存チェックボックスの動作確認
- [x] 保存したパスワードの自動読み込み確認
- [x] アプリ再起動時の自動接続確認
- [x] 戻るボタンでの適切な切断フロー確認
- [x] パスワード暗号化/復号化の動作確認
- [x] 複数接続でのパスワード管理確認
- [x] DataStore/Keystoreのデータ永続性確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)