### PR TITLE
Fix DECSCUSR escape sequence parsing to prevent 'q' character display

### DIFF
--- a/mobile-vibe-terminal/src/commonTest/kotlin/tokyo/isseikuzumaki/vibeterminal/terminal/AnsiEscapeParserTest.kt
+++ b/mobile-vibe-terminal/src/commonTest/kotlin/tokyo/isseikuzumaki/vibeterminal/terminal/AnsiEscapeParserTest.kt
@@ -552,4 +552,97 @@ class AnsiEscapeParserTest {
         assertEquals(3, buffer.cursorRow, "Should move up one line")
         assertEquals(4, buffer.cursorCol, "Column should not change")
     }
+
+    // ========== DECSCUSR - Set Cursor Style ==========
+
+    @Test
+    fun testDECSCUSR_BlinkingBlock() {
+        val (parser, buffer) = createParser()
+        buffer.moveCursor(1, 1)
+
+        parser.processText("\u001B[1 q")  // CSI 1 SP q - Blinking block cursor
+        parser.processText("X")
+
+        // The 'q' should not appear on screen - it should be consumed by the parser
+        assertEquals('X', buffer.getBuffer()[0][0].char, "Only 'X' should be written, not 'q'")
+        assertEquals(' ', buffer.getBuffer()[0][1].char, "Position after 'X' should be empty")
+    }
+
+    @Test
+    fun testDECSCUSR_SteadyBlock() {
+        val (parser, buffer) = createParser()
+        buffer.moveCursor(1, 1)
+
+        parser.processText("\u001B[2 q")  // CSI 2 SP q - Steady block cursor
+        parser.processText("X")
+
+        assertEquals('X', buffer.getBuffer()[0][0].char, "Only 'X' should be written, not 'q'")
+        assertEquals(' ', buffer.getBuffer()[0][1].char, "Position after 'X' should be empty")
+    }
+
+    @Test
+    fun testDECSCUSR_BlinkingUnderline() {
+        val (parser, buffer) = createParser()
+        buffer.moveCursor(1, 1)
+
+        parser.processText("\u001B[3 q")  // CSI 3 SP q - Blinking underline cursor
+        parser.processText("X")
+
+        assertEquals('X', buffer.getBuffer()[0][0].char, "Only 'X' should be written, not 'q'")
+    }
+
+    @Test
+    fun testDECSCUSR_SteadyUnderline() {
+        val (parser, buffer) = createParser()
+        buffer.moveCursor(1, 1)
+
+        parser.processText("\u001B[4 q")  // CSI 4 SP q - Steady underline cursor
+        parser.processText("X")
+
+        assertEquals('X', buffer.getBuffer()[0][0].char, "Only 'X' should be written, not 'q'")
+    }
+
+    @Test
+    fun testDECSCUSR_BlinkingBar() {
+        val (parser, buffer) = createParser()
+        buffer.moveCursor(1, 1)
+
+        parser.processText("\u001B[5 q")  // CSI 5 SP q - Blinking bar cursor
+        parser.processText("X")
+
+        assertEquals('X', buffer.getBuffer()[0][0].char, "Only 'X' should be written, not 'q'")
+    }
+
+    @Test
+    fun testDECSCUSR_SteadyBar() {
+        val (parser, buffer) = createParser()
+        buffer.moveCursor(1, 1)
+
+        parser.processText("\u001B[6 q")  // CSI 6 SP q - Steady bar cursor
+        parser.processText("X")
+
+        assertEquals('X', buffer.getBuffer()[0][0].char, "Only 'X' should be written, not 'q'")
+    }
+
+    @Test
+    fun testDECSCUSR_Default() {
+        val (parser, buffer) = createParser()
+        buffer.moveCursor(1, 1)
+
+        parser.processText("\u001B[0 q")  // CSI 0 SP q - Default cursor (blinking block)
+        parser.processText("X")
+
+        assertEquals('X', buffer.getBuffer()[0][0].char, "Only 'X' should be written, not 'q'")
+    }
+
+    @Test
+    fun testDECSCUSR_NoParameter() {
+        val (parser, buffer) = createParser()
+        buffer.moveCursor(1, 1)
+
+        parser.processText("\u001B[ q")  // CSI SP q - No parameter (default)
+        parser.processText("X")
+
+        assertEquals('X', buffer.getBuffer()[0][0].char, "Only 'X' should be written, not 'q'")
+    }
 }


### PR DESCRIPTION
## Summary
Fixes the issue where tmux/byobu cursor style control sequences were not properly parsed, causing the 'q' character to appear on screen.

## Problem
When using tmux or byobu, the terminal sends `ESC [ 2 SP q` (DECSCUSR - Set Cursor Style) sequences to change the cursor appearance. The parser was not recognizing Space (0x20) as an intermediate byte, causing it to:
1. Fail to parse the sequence correctly
2. Display the trailing 'q' character on screen
3. Create visual artifacts during screen transitions

## Solution
- Added `csiIntermediate` variable to track intermediate bytes in CSI sequences
- Modified `handleCsiChar()` to recognize Space (0x20) as an intermediate byte
- Implemented DECSCUSR (CSI Ps SP q) command handler that consumes the sequence
- The handler documents all cursor styles (0-6) and can be extended in the future to actually change cursor appearance

## Testing
- Added 8 comprehensive test cases covering all DECSCUSR cursor styles
- All existing tests pass
- Verified that the 'q' character no longer appears on screen during tmux/byobu operations

## Test plan
- [x] Unit tests pass
- [x] Deployed and tested on actual device with tmux/byobu
- [x] Screen transitions no longer show stray 'q' characters
- [x] No regression in other escape sequence handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)