### PR TITLE
Implement keyboard-aware layout for terminal screen

### DIFF
--- a/mobile-vibe-terminal/src/androidMain/AndroidManifest.xml
+++ b/mobile-vibe-terminal/src/androidMain/AndroidManifest.xml
@@ -14,7 +14,8 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:configChanges="orientation|screenSize|screenLayout|keyboardHidden">
+            android:configChanges="orientation|screenSize|screenLayout|keyboardHidden"
+            android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />


### PR DESCRIPTION
## Summary

This PR implements keyboard-aware layout management for the terminal screen, addressing two critical issues:

1. **UI Overlap Fix**: Terminal output and MacroInputPanel no longer overlap
2. **Keyboard Slide Behavior**: UI slides upward when keyboard appears, without resizing the terminal

## Changes

### Phase 1: Fix UI Overlap
- **File**: `TerminalScreen.kt` (Line 290)
- **Change**: `TerminalBufferView` now uses `Modifier.fillMaxWidth()` instead of `fillMaxSize()`
- **Effect**: Respects BoxWithConstraints height constraints, preventing overlap with MacroInputPanel

### Phase 2: Keyboard-Aware UI Sliding
- **File**: `TerminalScreen.kt` (Lines 105-123)
- **Changes**:
  - Added `WindowInsets.ime` detection
  - Implemented `animateDpAsState` for smooth slide animation
  - Applied `offset(y = imeOffsetDp)` to main Column
- **Effect**: UI slides upward when keyboard appears, slides back down when dismissed
- **Key advantage**: Uses `offset()` instead of `padding()` to avoid layout recalculation

### Phase 3: Lock Terminal Size
- **File**: `TerminalScreen.kt` (Lines 211-223)
- **Change**: Wrapped terminal size calculation in `remember` block
- **Effect**: rows/cols remain constant when keyboard shows/hides, preventing SSH PTY resize

### Phase 4: Android Manifest Configuration
- **File**: `AndroidManifest.xml` (Line 18)
- **Change**: Added `android:windowSoftInputMode="adjustResize"`
- **Effect**: Ensures proper IME handling on Android platform

## Technical Details

**Why offset() instead of padding()?**
- `offset()`: Doesn't trigger layout recalculation, BoxWithConstraints size unchanged
- `padding()`: Triggers recomposition, BoxWithConstraints sees smaller height, rows/cols recalculated

**Multiplatform Compatibility**:
- Android: Full WindowInsets.ime support
- iOS: WindowInsets.ime supported (Compose Multiplatform)
- Desktop: No soft keyboard, offset remains 0.dp (safe)

## Testing

### Required Tests
- [ ] UI Overlap: Verify MacroInputPanel doesn't overlap terminal output
- [ ] CMD Mode Keyboard: Tap terminal → keyboard shows → UI slides up → type chars → keyboard hides → UI slides down
- [ ] TEXT Mode Keyboard: Toggle TEXT mode → tap text field → keyboard shows → UI slides up
- [ ] Terminal Size Stability: Verify rows/cols unchanged when keyboard shows/hides (check logs)

### Test Environment
- Device: Android (recommended: physical device for accurate keyboard behavior)
- Build: Debug APK from this branch

## Related Issues

Closes related to terminal layout and keyboard handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)