### PR TITLE
feat: configure debug signing for Android builds

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -92,12 +92,30 @@ android {
         versionCode = 1
         versionName = "1.0"
     }
+
+    signingConfigs {
+        getByName("debug") {
+            val keystoreFile = rootProject.file("debug.keystore")
+            if (keystoreFile.exists()) {
+                storeFile = keystoreFile
+            } else {
+                storeFile = file("${System.getProperty("user.home")}/.android/debug.keystore")
+            }
+            storePassword = "android"
+            keyAlias = "androiddebugkey"
+            keyPassword = "android"
+        }
+    }
+
     packaging {
         resources {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
         }
     }
     buildTypes {
+        getByName("debug") {
+            signingConfig = signingConfigs.getByName("debug")
+        }
         getByName("release") {
             isMinifyEnabled = false
         }

--- a/mobile-vibe-terminal/build.gradle.kts
+++ b/mobile-vibe-terminal/build.gradle.kts
@@ -123,7 +123,12 @@ android {
 
     signingConfigs {
         getByName("debug") {
-            storeFile = file("${System.getProperty("user.home")}/.android/debug.keystore")
+            val keystoreFile = rootProject.file("debug.keystore")
+            if (keystoreFile.exists()) {
+                storeFile = keystoreFile
+            } else {
+                storeFile = file("${System.getProperty("user.home")}/.android/debug.keystore")
+            }
             storePassword = "android"
             keyAlias = "androiddebugkey"
             keyPassword = "android"

--- a/nlt-app/build.gradle.kts
+++ b/nlt-app/build.gradle.kts
@@ -80,7 +80,21 @@ android {
         versionCode = 1
         versionName = "1.0"
     }
-    
+
+    signingConfigs {
+        getByName("debug") {
+            val keystoreFile = rootProject.file("debug.keystore")
+            if (keystoreFile.exists()) {
+                storeFile = keystoreFile
+            } else {
+                storeFile = file("${System.getProperty("user.home")}/.android/debug.keystore")
+            }
+            storePassword = "android"
+            keyAlias = "androiddebugkey"
+            keyPassword = "android"
+        }
+    }
+
     packaging {
         resources {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
@@ -88,6 +102,9 @@ android {
     }
     
     buildTypes {
+        getByName("debug") {
+            signingConfig = signingConfigs.getByName("debug")
+        }
         getByName("release") {
             isMinifyEnabled = false
         }

--- a/unison-app/build.gradle.kts
+++ b/unison-app/build.gradle.kts
@@ -68,6 +68,20 @@ android {
         versionName = "1.0"
     }
 
+    signingConfigs {
+        getByName("debug") {
+            val keystoreFile = rootProject.file("debug.keystore")
+            if (keystoreFile.exists()) {
+                storeFile = keystoreFile
+            } else {
+                storeFile = file("${System.getProperty("user.home")}/.android/debug.keystore")
+            }
+            storePassword = "android"
+            keyAlias = "androiddebugkey"
+            keyPassword = "android"
+        }
+    }
+
     packaging {
         resources {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
@@ -75,6 +89,9 @@ android {
     }
 
     buildTypes {
+        getByName("debug") {
+            signingConfig = signingConfigs.getByName("debug")
+        }
         getByName("release") {
             isMinifyEnabled = false
         }


### PR DESCRIPTION
This pull request standardizes and improves the debug signing configuration across multiple Android modules. The main change is to ensure that the debug build uses a consistent keystore, preferring a project-local `debug.keystore` if it exists, and falling back to the user's default keystore otherwise. This helps avoid signing issues during development and ensures reproducibility across environments.

Key changes by theme:

**Debug signing configuration improvements:**

* Added a `signingConfigs` block to the `android` section of `composeApp/build.gradle.kts`, `nlt-app/build.gradle.kts`, and `unison-app/build.gradle.kts` to configure the debug keystore. The configuration checks for a local `debug.keystore` file and uses it if present, otherwise defaults to the standard keystore in the user's home directory. (`composeApp/build.gradle.kts` [[1]](diffhunk://#diff-9ea83bf74425e7270f5dd624644cc4500977afeb671f9578fabdec009eb4ba4aR95-R118) `nlt-app/build.gradle.kts` [[2]](diffhunk://#diff-a68d6f3ae84143fe28879915fb000d2c035c210bd59377ee9ec6797a5f287eb8R84-R107) `unison-app/build.gradle.kts` [[3]](diffhunk://#diff-add49e28126f9a94fbdcd2f05d6de29d661b48620871aa9e5a68556630bff65cR71-R94)
* Updated the `buildTypes` block in the same files to explicitly set the debug build type to use the configured debug signing config. (`composeApp/build.gradle.kts` [[1]](diffhunk://#diff-9ea83bf74425e7270f5dd624644cc4500977afeb671f9578fabdec009eb4ba4aR95-R118) `nlt-app/build.gradle.kts` [[2]](diffhunk://#diff-a68d6f3ae84143fe28879915fb000d2c035c210bd59377ee9ec6797a5f287eb8R84-R107) `unison-app/build.gradle.kts` [[3]](diffhunk://#diff-add49e28126f9a94fbdcd2f05d6de29d661b48620871aa9e5a68556630bff65cR71-R94)
* Improved the debug signing configuration in `mobile-vibe-terminal/build.gradle.kts` to follow the same pattern, checking for a local `debug.keystore` before falling back to the default. (`mobile-vibe-terminal/build.gradle.kts` [mobile-vibe-terminal/build.gradle.ktsR126-R131](diffhunk://#diff-764b37f2061363d1b842221f784044d6a5a7f4629292a3653ceab0cb1b1d4749R126-R131))