### PR TITLE
Fix AndroidManifest to prevent activity recreation by HW keyboard

### DIFF
--- a/mobile-vibe-terminal/src/androidMain/AndroidManifest.xml
+++ b/mobile-vibe-terminal/src/androidMain/AndroidManifest.xml
@@ -19,7 +19,7 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:configChanges="orientation|screenSize|screenLayout|keyboardHidden|uiMode|density|smallestScreenSize"
+            android:configChanges="orientation|screenSize|screenLayout|keyboard|keyboardHidden|navigation|uiMode|density|smallestScreenSize"
             android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
## 概要
`AndroidManifest.xml` の `MainActivity` における `android:configChanges` 設定を更新しました。

## 課題 (Problem)
物理キーボードの接続・切断時や、ナビゲーションデバイス（D-padやトラックボールなど）の変更が検知された際に、`MainActivity` が再起動（破棄と再生成）されていました。これにより、実行中のターミナルセッションや一時的なUI状態がリセットされてしまう問題がありました。

## 原因 (Cause)
Androidのデフォルトの挙動では、デバイスの設定（Configuration）が変更されると、リソースを再読み込みするためにActivityが再起動されます。これまで `android:configChanges` に `keyboard` と `navigation` が含まれていなかったため、これらのハードウェア構成変更が発生した際にシステムがActivityの再起動をトリガーしていました。

## 解決策 (Solution)
`android:configChanges` 属性に `keyboard` と `navigation` を追加しました。
これにより、該当する設定変更が発生してもシステムによるActivityの自動再起動が行われず、現在のセッション状態を維持したまま動作を継続できるようになります。