### PR TITLE
fix: correct terminal size calculation for secondary display

### DIFF
--- a/mobile-vibe-terminal/src/commonMain/kotlin/tokyo/isseikuzumaki/vibeterminal/ui/components/TerminalCanvas.kt
+++ b/mobile-vibe-terminal/src/commonMain/kotlin/tokyo/isseikuzumaki/vibeterminal/ui/components/TerminalCanvas.kt
@@ -7,14 +7,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.TextMeasurer
 import androidx.compose.ui.text.drawText
 import androidx.compose.ui.text.rememberTextMeasurer
-import androidx.compose.ui.unit.sp // Import sp
 import tokyo.isseikuzumaki.vibeterminal.terminal.TerminalCell
 import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
+import tokyo.isseikuzumaki.vibeterminal.terminal.TerminalFontConfig
 
 @Composable
 fun TerminalCanvas(
@@ -25,8 +23,8 @@ fun TerminalCanvas(
 ) {
     val textMeasurer = rememberTextMeasurer()
     val textStyle = TextStyle(
-        fontFamily = FontFamily.Monospace,
-        fontSize = 14.sp
+        fontFamily = TerminalFontConfig.fontFamily,
+        fontSize = TerminalFontConfig.fontSize
     )
 
     // Calculate cell dimensions based on a sample char


### PR DESCRIPTION
## Summary
- Use `WindowMetrics` (API 30+) or `display.getRealSize()` to get actual secondary display dimensions instead of primary display metrics
- Get density from secondary display for accurate font size calculation
- Unify font settings in `TerminalCanvas` to use `TerminalFontConfig` (was hardcoded to 14sp, now uses 12sp from config)
- Request terminal resize when buffer size differs from calculated dimensions (not just when exceeding)

## Test plan
- [ ] Connect secondary display (1920x1080)
- [ ] Launch terminal and connect to SSH
- [ ] Verify terminal uses full available rows (should be ~38 rows for 1080p)
- [ ] Verify bottom rows are not clipped outside display

🤖 Generated with [Claude Code](https://claude.com/claude-code)