### PR TITLE
feat: Material Design 3準拠のUIリファイン

### DIFF
--- a/mobile-vibe-terminal/src/androidMain/kotlin/tokyo/isseikuzumaki/vibeterminal/MainActivity.kt
+++ b/mobile-vibe-terminal/src/androidMain/kotlin/tokyo/isseikuzumaki/vibeterminal/MainActivity.kt
@@ -17,6 +17,7 @@ import tokyo.isseikuzumaki.vibeterminal.platform.launchSecondaryDisplay
 import tokyo.isseikuzumaki.vibeterminal.terminal.TerminalStateProvider
 import tokyo.isseikuzumaki.vibeterminal.ui.components.TriggerEventHost
 import tokyo.isseikuzumaki.vibeterminal.ui.screens.ConnectionListScreen
+import tokyo.isseikuzumaki.vibeterminal.ui.theme.VibeTerminalTheme
 import tokyo.isseikuzumaki.vibeterminal.util.Logger
 
 class MainActivity : ComponentActivity() {
@@ -47,8 +48,10 @@ class MainActivity : ComponentActivity() {
 
         enableEdgeToEdge()
         setContent {
-            TriggerEventHost {
-                Navigator(ConnectionListScreen())
+            VibeTerminalTheme {
+                TriggerEventHost {
+                    Navigator(ConnectionListScreen())
+                }
             }
         }
     }

--- a/mobile-vibe-terminal/src/commonMain/kotlin/tokyo/isseikuzumaki/vibeterminal/ui/components/macro/MacroButton.kt
+++ b/mobile-vibe-terminal/src/commonMain/kotlin/tokyo/isseikuzumaki/vibeterminal/ui/components/macro/MacroButton.kt
@@ -3,13 +3,14 @@ package tokyo.isseikuzumaki.vibeterminal.ui.components.macro
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.height
-import androidx.compose.material3.Button
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.focusProperties
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -21,23 +22,29 @@ fun MacroButton(
     isEmphasis: Boolean = false,
     modifier: Modifier = Modifier
 ) {
-    Button(
+    OutlinedButton(
         onClick = onClick,
-        colors = ButtonDefaults.buttonColors(
+        shape = RoundedCornerShape(50),
+        colors = ButtonDefaults.outlinedButtonColors(
             containerColor = if (isEmphasis) {
-                Color(0xFF39D353).copy(alpha = 0.2f)
+                MaterialTheme.colorScheme.primary.copy(alpha = 0.1f)
             } else {
-                Color(0xFF2A2A2A)
+                MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
             },
             contentColor = if (isEmphasis) {
-                Color(0xFF39D353)
+                MaterialTheme.colorScheme.primary
             } else {
-                Color(0xFF00FF00)
+                MaterialTheme.colorScheme.onSurfaceVariant
             }
         ),
-        border = if (isEmphasis) {
-            BorderStroke(1.dp, Color(0xFF39D353))
-        } else null,
+        border = BorderStroke(
+            width = 1.dp,
+            color = if (isEmphasis) {
+                MaterialTheme.colorScheme.primary
+            } else {
+                MaterialTheme.colorScheme.outline.copy(alpha = 0.5f)
+            }
+        ),
         contentPadding = PaddingValues(horizontal = 12.dp, vertical = 6.dp),
         modifier = modifier.height(36.dp).focusProperties { canFocus = false }
     ) {

--- a/mobile-vibe-terminal/src/commonMain/kotlin/tokyo/isseikuzumaki/vibeterminal/ui/components/macro/MacroInputPanel.kt
+++ b/mobile-vibe-terminal/src/commonMain/kotlin/tokyo/isseikuzumaki/vibeterminal/ui/components/macro/MacroInputPanel.kt
@@ -1,18 +1,12 @@
 package tokyo.isseikuzumaki.vibeterminal.ui.components.macro
 
-import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
-import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.focus.focusProperties
 import androidx.compose.material.icons.Icons
@@ -38,12 +32,12 @@ fun MacroInputPanel(
     onToggleCtrl: () -> Unit,
     onToggleAlt: () -> Unit,
     modifier: Modifier = Modifier,
-    terminalInputState: TerminalInputContainerState? = null // Added for wrapping the keyboard toggle button
+    terminalInputState: TerminalInputContainerState? = null
 ) {
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .background(Color(0xFF1A1A1A))
+            .background(MaterialTheme.colorScheme.surface)
     ) {
         // Tab Row
         MacroTabRow(
@@ -53,7 +47,7 @@ fun MacroInputPanel(
         )
 
         HorizontalDivider(
-            color = Color(0xFF00FF00).copy(alpha = 0.3f),
+            color = MaterialTheme.colorScheme.outline.copy(alpha = 0.3f),
             thickness = 1.dp
         )
 
@@ -65,13 +59,12 @@ fun MacroInputPanel(
                 onDirectSend(sequence)
             },
             onBufferInsert = { text ->
-                // Directly send text macros instead of buffering
                 onDirectSend(text)
             }
         )
 
         HorizontalDivider(
-            color = Color(0xFF00FF00).copy(alpha = 0.3f),
+            color = MaterialTheme.colorScheme.outline.copy(alpha = 0.3f),
             thickness = 1.dp
         )
 
@@ -83,31 +76,27 @@ fun MacroInputPanel(
             horizontalArrangement = Arrangement.spacedBy(8.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            // IME Mode Toggle (DIRECT / IME)
+            // IME Mode Toggle (TEXT MODE is special - uses primary color outline)
             FilterChip(
                 selected = state.isImeEnabled,
                 onClick = onToggleImeMode,
-                // Using existing string resources:
-                // macro_cmd_mode -> "CMD MODE" -> DIRECT
-                // macro_text_mode -> "TEXT MODE" -> IME
                 label = { Text(if (state.isImeEnabled) stringResource(Res.string.macro_text_mode) else stringResource(Res.string.macro_cmd_mode)) },
                 colors = FilterChipDefaults.filterChipColors(
-                    selectedContainerColor = Color(0xFF00FF00),
-                    selectedLabelColor = Color.Black,
-                    containerColor = Color.DarkGray,
-                    labelColor = Color.White
+                    selectedContainerColor = MaterialTheme.colorScheme.primary,
+                    selectedLabelColor = MaterialTheme.colorScheme.onPrimary,
+                    containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                    labelColor = MaterialTheme.colorScheme.onSurfaceVariant
                 ),
                 border = FilterChipDefaults.filterChipBorder(
                     enabled = true,
                     selected = state.isImeEnabled,
-                    borderColor = Color(0xFF00FF00).copy(alpha = 0.5f),
-                    selectedBorderColor = Color(0xFF00FF00)
+                    borderColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.5f),
+                    selectedBorderColor = MaterialTheme.colorScheme.primary
                 ),
                 modifier = Modifier.focusProperties { canFocus = false }
             )
 
             // Keyboard Visibility Toggle
-            // Wrapped in TerminalInputContainer if state is provided
             if (terminalInputState != null) {
                 TerminalInputContainer(
                     state = terminalInputState,
@@ -116,7 +105,7 @@ fun MacroInputPanel(
                     IconButton(
                         onClick = onToggleSoftKeyboard,
                         colors = IconButtonDefaults.iconButtonColors(
-                            contentColor = if (state.isSoftKeyboardVisible) Color(0xFF00FF00) else Color.Gray
+                            contentColor = if (state.isSoftKeyboardVisible) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant
                         )
                     ) {
                         Icon(
@@ -129,7 +118,7 @@ fun MacroInputPanel(
                 IconButton(
                     onClick = onToggleSoftKeyboard,
                     colors = IconButtonDefaults.iconButtonColors(
-                        contentColor = if (state.isSoftKeyboardVisible) Color(0xFF00FF00) else Color.Gray
+                        contentColor = if (state.isSoftKeyboardVisible) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant
                     )
                 ) {
                     Icon(
@@ -147,16 +136,16 @@ fun MacroInputPanel(
                 onClick = onToggleCtrl,
                 label = { Text(stringResource(Res.string.macro_ctrl)) },
                 colors = FilterChipDefaults.filterChipColors(
-                    selectedContainerColor = Color(0xFF00FF00),
-                    selectedLabelColor = Color.Black,
-                    containerColor = Color.DarkGray,
-                    labelColor = Color.White
+                    selectedContainerColor = MaterialTheme.colorScheme.primary,
+                    selectedLabelColor = MaterialTheme.colorScheme.onPrimary,
+                    containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                    labelColor = MaterialTheme.colorScheme.onSurfaceVariant
                 ),
                 border = FilterChipDefaults.filterChipBorder(
                     enabled = true,
                     selected = state.isCtrlActive,
-                    borderColor = Color(0xFF00FF00).copy(alpha = 0.5f),
-                    selectedBorderColor = Color(0xFF00FF00)
+                    borderColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.5f),
+                    selectedBorderColor = MaterialTheme.colorScheme.primary
                 ),
                 modifier = Modifier.focusProperties { canFocus = false }
             )
@@ -167,16 +156,16 @@ fun MacroInputPanel(
                 onClick = onToggleAlt,
                 label = { Text(stringResource(Res.string.macro_alt)) },
                 colors = FilterChipDefaults.filterChipColors(
-                    selectedContainerColor = Color(0xFF00FF00),
-                    selectedLabelColor = Color.Black,
-                    containerColor = Color.DarkGray,
-                    labelColor = Color.White
+                    selectedContainerColor = MaterialTheme.colorScheme.primary,
+                    selectedLabelColor = MaterialTheme.colorScheme.onPrimary,
+                    containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                    labelColor = MaterialTheme.colorScheme.onSurfaceVariant
                 ),
                 border = FilterChipDefaults.filterChipBorder(
                     enabled = true,
                     selected = state.isAltActive,
-                    borderColor = Color(0xFF00FF00).copy(alpha = 0.5f),
-                    selectedBorderColor = Color(0xFF00FF00)
+                    borderColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.5f),
+                    selectedBorderColor = MaterialTheme.colorScheme.primary
                 ),
                 modifier = Modifier.focusProperties { canFocus = false }
             )

--- a/mobile-vibe-terminal/src/commonMain/kotlin/tokyo/isseikuzumaki/vibeterminal/ui/components/macro/MacroTabRow.kt
+++ b/mobile-vibe-terminal/src/commonMain/kotlin/tokyo/isseikuzumaki/vibeterminal/ui/components/macro/MacroTabRow.kt
@@ -1,5 +1,6 @@
 package tokyo.isseikuzumaki.vibeterminal.ui.components.macro
 
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ScrollableTabRow
 import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRowDefaults
@@ -7,7 +8,6 @@ import androidx.compose.material3.TabRowDefaults.tabIndicatorOffset
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.sp
 import org.jetbrains.compose.resources.stringResource
 import puzzroom.mobile_vibe_terminal.generated.resources.*
@@ -21,16 +21,12 @@ fun MacroTabRow(
 ) {
     ScrollableTabRow(
         selectedTabIndex = selectedTab.ordinal,
-        containerColor = Color(0xFF1A1A1A),
-        contentColor = Color(0xFF00FF00),
+        containerColor = MaterialTheme.colorScheme.surface,
+        contentColor = MaterialTheme.colorScheme.primary,
         indicator = { tabPositions ->
             TabRowDefaults.SecondaryIndicator(
                 modifier = Modifier.tabIndicatorOffset(tabPositions[selectedTab.ordinal]),
-                color = if (isAlternateScreen && selectedTab == MacroTab.VIM) {
-                    Color(0xFF39D353)
-                } else {
-                    Color(0xFF00FF00)
-                }
+                color = MaterialTheme.colorScheme.primary
             )
         },
         modifier = modifier
@@ -39,6 +35,8 @@ fun MacroTabRow(
             Tab(
                 selected = selectedTab == tab,
                 onClick = { onTabSelected(tab) },
+                selectedContentColor = MaterialTheme.colorScheme.primary,
+                unselectedContentColor = MaterialTheme.colorScheme.onSurfaceVariant,
                 text = {
                     Text(
                         text = when (tab) {

--- a/mobile-vibe-terminal/src/commonMain/kotlin/tokyo/isseikuzumaki/vibeterminal/ui/screens/ConnectionListScreen.kt
+++ b/mobile-vibe-terminal/src/commonMain/kotlin/tokyo/isseikuzumaki/vibeterminal/ui/screens/ConnectionListScreen.kt
@@ -1,20 +1,24 @@
 package tokyo.isseikuzumaki.vibeterminal.ui.screens
 
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
@@ -73,8 +77,8 @@ class ConnectionListScreen : Screen {
                 TopAppBar(
                     title = { Text(stringResource(Res.string.connection_list_title)) },
                     colors = TopAppBarDefaults.topAppBarColors(
-                        containerColor = Color(0xFF1A1A1A),
-                        titleContentColor = Color(0xFF00FF00)
+                        containerColor = MaterialTheme.colorScheme.surface,
+                        titleContentColor = MaterialTheme.colorScheme.primary
                     ),
                     actions = {
                         // Display connection indicator (informational only)
@@ -82,7 +86,7 @@ class ConnectionListScreen : Screen {
                             Text(
                                 text = stringResource(Res.string.connection_list_test_display),
                                 fontSize = 12.sp,
-                                color = Color(0xFF00FF00),
+                                color = MaterialTheme.colorScheme.primary,
                                 modifier = Modifier.padding(end = 16.dp)
                             )
                         }
@@ -93,7 +97,7 @@ class ConnectionListScreen : Screen {
                                 Icon(
                                     Icons.Default.Settings,
                                     contentDescription = "Settings",
-                                    tint = Color(0xFF00FF00)
+                                    tint = MaterialTheme.colorScheme.primary
                                 )
                             }
                             DropdownMenu(
@@ -109,7 +113,7 @@ class ConnectionListScreen : Screen {
                                             Icon(
                                                 Icons.Default.Settings,
                                                 contentDescription = null,
-                                                tint = Color(0xFF00FF00),
+                                                tint = MaterialTheme.colorScheme.primary,
                                                 modifier = Modifier.size(20.dp)
                                             )
                                             Spacer(Modifier.width(12.dp))
@@ -118,7 +122,7 @@ class ConnectionListScreen : Screen {
                                                 Text(
                                                     "Manage public key authentication",
                                                     style = MaterialTheme.typography.bodySmall,
-                                                    color = Color.Gray
+                                                    color = MaterialTheme.colorScheme.onSurfaceVariant
                                                 )
                                             }
                                         }
@@ -140,7 +144,7 @@ class ConnectionListScreen : Screen {
                                                 Text(
                                                     stringResource(Res.string.settings_auto_install_description),
                                                     style = MaterialTheme.typography.bodySmall,
-                                                    color = Color.Gray
+                                                    color = MaterialTheme.colorScheme.onSurfaceVariant
                                                 )
                                             }
                                             Switch(
@@ -167,8 +171,8 @@ class ConnectionListScreen : Screen {
             floatingActionButton = {
                 FloatingActionButton(
                     onClick = { screenModel.showAddDialog() },
-                    containerColor = Color(0xFF00FF00),
-                    contentColor = Color.Black
+                    containerColor = MaterialTheme.colorScheme.primary,
+                    contentColor = MaterialTheme.colorScheme.onPrimary
                 ) {
                     Icon(Icons.Default.Add, stringResource(Res.string.connection_list_add))
                 }
@@ -189,13 +193,13 @@ class ConnectionListScreen : Screen {
                             Text(
                                 stringResource(Res.string.connection_list_empty_title),
                                 style = MaterialTheme.typography.headlineSmall,
-                                color = Color.Gray
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
                             )
                             Spacer(modifier = Modifier.height(8.dp))
                             Text(
                                 stringResource(Res.string.connection_list_empty_message),
                                 style = MaterialTheme.typography.bodyMedium,
-                                color = Color.Gray
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
                             )
                         }
                     }
@@ -319,46 +323,75 @@ class ConnectionListScreen : Screen {
         onDelete: () -> Unit
     ) {
         Card(
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable(onClick = onConnect),
+            shape = RoundedCornerShape(16.dp),
             colors = CardDefaults.cardColors(
-                containerColor = Color(0xFF2A2A2A)
+                containerColor = MaterialTheme.colorScheme.surface
             )
         ) {
-            Column(
-                modifier = Modifier.padding(16.dp)
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.Top
             ) {
-                Text(
-                    text = connection.name,
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.Bold,
-                    color = Color(0xFF00FF00)
-                )
-                Spacer(modifier = Modifier.height(8.dp))
-                Text(
-                    text = "${connection.username}@${connection.host}:${connection.port}",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = Color.White
-                )
-                Spacer(modifier = Modifier.height(16.dp))
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                // Left side: Host info
+                Column(
+                    modifier = Modifier.weight(1f)
                 ) {
-                    Button(
-                        onClick = onConnect,
-                        modifier = Modifier.weight(1f),
-                        colors = ButtonDefaults.buttonColors(
-                            containerColor = Color(0xFF00FF00),
-                            contentColor = Color.Black
-                        )
-                    ) {
-                        Text(stringResource(Res.string.action_connect))
-                    }
-                    IconButton(onClick = onEdit) {
-                        Icon(Icons.Default.Edit, stringResource(Res.string.action_edit), tint = Color(0xFF00FF00))
-                    }
-                    IconButton(onClick = onDelete) {
-                        Icon(Icons.Default.Delete, stringResource(Res.string.action_delete), tint = Color.Red)
+                    Text(
+                        text = connection.name,
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.onSurface
+                    )
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(
+                        text = "${connection.username}@${connection.host}:${connection.port}",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+
+                // Right side: Actions
+                Column(
+                    horizontalAlignment = Alignment.End
+                ) {
+                    // Connect indicator
+                    Icon(
+                        Icons.Default.PlayArrow,
+                        contentDescription = stringResource(Res.string.action_connect),
+                        tint = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.size(24.dp)
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    // Edit and Delete icons
+                    Row {
+                        IconButton(
+                            onClick = onEdit,
+                            modifier = Modifier.size(32.dp)
+                        ) {
+                            Icon(
+                                Icons.Default.Edit,
+                                stringResource(Res.string.action_edit),
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.size(18.dp)
+                            )
+                        }
+                        IconButton(
+                            onClick = onDelete,
+                            modifier = Modifier.size(32.dp)
+                        ) {
+                            Icon(
+                                Icons.Default.Delete,
+                                stringResource(Res.string.action_delete),
+                                tint = MaterialTheme.colorScheme.error,
+                                modifier = Modifier.size(18.dp)
+                            )
+                        }
                     }
                 }
             }
@@ -387,11 +420,21 @@ class ConnectionListScreen : Screen {
 
         AlertDialog(
             onDismissRequest = onDismiss,
-            title = { Text(stringResource(if (connection == null) Res.string.connection_dialog_add_title else Res.string.connection_dialog_edit_title)) },
+            shape = RoundedCornerShape(28.dp),
+            containerColor = MaterialTheme.colorScheme.surface,
+            title = {
+                Text(
+                    text = stringResource(if (connection == null) Res.string.connection_dialog_add_title else Res.string.connection_dialog_edit_title),
+                    style = MaterialTheme.typography.headlineSmall,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+            },
             text = {
                 Column(
-                    modifier = Modifier.fillMaxWidth(),
-                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .verticalScroll(rememberScrollState()),
+                    verticalArrangement = Arrangement.spacedBy(16.dp)
                 ) {
                     OutlinedTextField(
                         value = name,
@@ -424,25 +467,39 @@ class ConnectionListScreen : Screen {
                     )
 
                     // Authentication Type Selection
-                    Text(
-                        text = "Authentication",
-                        style = MaterialTheme.typography.labelMedium,
-                        modifier = Modifier.padding(top = 8.dp)
-                    )
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.spacedBy(8.dp)
-                    ) {
-                        FilterChip(
-                            selected = authType == "password",
-                            onClick = { authType = "password" },
-                            label = { Text("Password") }
+                    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                        Text(
+                            text = "Authentication",
+                            style = MaterialTheme.typography.titleSmall,
+                            color = MaterialTheme.colorScheme.onSurface
                         )
-                        FilterChip(
-                            selected = authType == "key",
-                            onClick = { authType = "key" },
-                            label = { Text("Public Key") }
-                        )
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.spacedBy(8.dp)
+                        ) {
+                            FilterChip(
+                                selected = authType == "password",
+                                onClick = { authType = "password" },
+                                label = { Text("Password") },
+                                colors = FilterChipDefaults.filterChipColors(
+                                    selectedContainerColor = MaterialTheme.colorScheme.primary,
+                                    selectedLabelColor = MaterialTheme.colorScheme.onPrimary,
+                                    containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                                    labelColor = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            )
+                            FilterChip(
+                                selected = authType == "key",
+                                onClick = { authType = "key" },
+                                label = { Text("Public Key") },
+                                colors = FilterChipDefaults.filterChipColors(
+                                    selectedContainerColor = MaterialTheme.colorScheme.primary,
+                                    selectedLabelColor = MaterialTheme.colorScheme.onPrimary,
+                                    containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                                    labelColor = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            )
+                        }
                     }
 
                     // Key Selection (shown when authType is "key")
@@ -452,7 +509,7 @@ class ConnectionListScreen : Screen {
                             Text(
                                 text = "No SSH keys available. Create keys in Settings > SSH Keys.",
                                 style = MaterialTheme.typography.bodySmall,
-                                color = Color.Red,
+                                color = MaterialTheme.colorScheme.error,
                                 modifier = Modifier.padding(vertical = 8.dp)
                             )
                         } else {
@@ -487,7 +544,7 @@ class ConnectionListScreen : Screen {
                                                     Text(
                                                         text = key.algorithm,
                                                         style = MaterialTheme.typography.bodySmall,
-                                                        color = Color.Gray
+                                                        color = MaterialTheme.colorScheme.onSurfaceVariant
                                                     )
                                                 }
                                             },
@@ -578,13 +635,22 @@ class ConnectionListScreen : Screen {
                         onSave(savedConnection)
                     },
                     enabled = name.isNotBlank() && host.isNotBlank() && username.isNotBlank() &&
-                              (authType == "password" || (authType == "key" && keyAlias.isNotBlank()))
+                              (authType == "password" || (authType == "key" && keyAlias.isNotBlank())),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.primary,
+                        contentColor = MaterialTheme.colorScheme.onPrimary
+                    )
                 ) {
                     Text(stringResource(Res.string.action_save))
                 }
             },
             dismissButton = {
-                TextButton(onClick = onDismiss) {
+                TextButton(
+                    onClick = onDismiss,
+                    colors = ButtonDefaults.textButtonColors(
+                        contentColor = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                ) {
                     Text(stringResource(Res.string.action_cancel))
                 }
             }
@@ -603,14 +669,24 @@ class ConnectionListScreen : Screen {
     ) {
         AlertDialog(
             onDismissRequest = onDismiss,
-            title = { Text(stringResource(Res.string.password_dialog_title)) },
+            shape = RoundedCornerShape(28.dp),
+            containerColor = MaterialTheme.colorScheme.surface,
+            title = {
+                Text(
+                    text = stringResource(Res.string.password_dialog_title),
+                    style = MaterialTheme.typography.headlineSmall,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+            },
             text = {
-                Column {
+                Column(
+                    verticalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
                     Text(
                         text = stringResource(Res.string.password_dialog_connecting_to, connection.name),
-                        style = MaterialTheme.typography.bodyMedium
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
-                    Spacer(modifier = Modifier.height(8.dp))
                     OutlinedTextField(
                         value = password,
                         onValueChange = onPasswordChange,
@@ -620,19 +696,23 @@ class ConnectionListScreen : Screen {
                         singleLine = true,
                         modifier = Modifier.fillMaxWidth()
                     )
-                    Spacer(modifier = Modifier.height(8.dp))
                     Row(
                         modifier = Modifier.fillMaxWidth(),
                         verticalAlignment = Alignment.CenterVertically
                     ) {
                         Checkbox(
                             checked = savePassword,
-                            onCheckedChange = onSavePasswordChange
+                            onCheckedChange = onSavePasswordChange,
+                            colors = CheckboxDefaults.colors(
+                                checkedColor = MaterialTheme.colorScheme.primary,
+                                checkmarkColor = MaterialTheme.colorScheme.onPrimary
+                            )
                         )
                         Text(
                             text = stringResource(Res.string.password_dialog_remember),
                             modifier = Modifier.padding(start = 8.dp),
-                            style = MaterialTheme.typography.bodySmall
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
                         )
                     }
                 }
@@ -640,13 +720,22 @@ class ConnectionListScreen : Screen {
             confirmButton = {
                 Button(
                     onClick = onConnect,
-                    enabled = password.isNotBlank()
+                    enabled = password.isNotBlank(),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.primary,
+                        contentColor = MaterialTheme.colorScheme.onPrimary
+                    )
                 ) {
                     Text(stringResource(Res.string.action_connect))
                 }
             },
             dismissButton = {
-                TextButton(onClick = onDismiss) {
+                TextButton(
+                    onClick = onDismiss,
+                    colors = ButtonDefaults.textButtonColors(
+                        contentColor = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                ) {
                     Text(stringResource(Res.string.action_cancel))
                 }
             }

--- a/mobile-vibe-terminal/src/commonMain/kotlin/tokyo/isseikuzumaki/vibeterminal/ui/screens/TerminalScreen.kt
+++ b/mobile-vibe-terminal/src/commonMain/kotlin/tokyo/isseikuzumaki/vibeterminal/ui/screens/TerminalScreen.kt
@@ -206,22 +206,22 @@ data class TerminalScreen(
                             if (isLoadingInitialPath) {
                                 CircularProgressIndicator(
                                     modifier = Modifier.size(24.dp),
-                                    color = Color(0xFF00FF00),
+                                    color = MaterialTheme.colorScheme.primary,
                                     strokeWidth = 2.dp
                                 )
                             } else {
                                 Icon(
                                     Icons.Default.FolderOpen,
                                     stringResource(Res.string.terminal_file_explorer),
-                                    tint = if (state.isConnected) Color(0xFF00FF00) else Color.Gray
+                                    tint = if (state.isConnected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant
                                 )
                             }
                         }
                     },
                     colors = TopAppBarDefaults.topAppBarColors(
-                        containerColor = Color(0xFF1A1A1A),
-                        titleContentColor = Color(0xFF00FF00),
-                        navigationIconContentColor = Color(0xFF00FF00)
+                        containerColor = MaterialTheme.colorScheme.surface,
+                        titleContentColor = MaterialTheme.colorScheme.primary,
+                        navigationIconContentColor = MaterialTheme.colorScheme.primary
                     )
                 )
             }
@@ -250,7 +250,7 @@ data class TerminalScreen(
                 if (state.isConnecting) {
                     LinearProgressIndicator(
                         modifier = Modifier.fillMaxWidth(),
-                        color = Color(0xFF00FF00)
+                        color = MaterialTheme.colorScheme.primary
                     )
                 }
 
@@ -259,19 +259,19 @@ data class TerminalScreen(
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .background(Color(0xFF2D2D00))
+                            .background(MaterialTheme.colorScheme.tertiaryContainer)
                             .padding(8.dp),
                         verticalAlignment = Alignment.CenterVertically
                     ) {
                         CircularProgressIndicator(
                             modifier = Modifier.size(16.dp),
-                            color = Color(0xFFFFAA00),
+                            color = MaterialTheme.colorScheme.tertiary,
                             strokeWidth = 2.dp
                         )
                         Spacer(modifier = Modifier.width(8.dp))
                         Text(
                             text = stringResource(Res.string.terminal_reconnecting),
-                            color = Color(0xFFFFAA00),
+                            color = MaterialTheme.colorScheme.tertiary,
                             fontSize = 12.sp
                         )
                     }
@@ -281,7 +281,7 @@ data class TerminalScreen(
                 state.errorMessage?.let { error ->
                     Text(
                         text = error,
-                        color = Color.Red,
+                        color = MaterialTheme.colorScheme.error,
                         modifier = Modifier.padding(8.dp),
                         fontSize = 12.sp
                     )
@@ -522,7 +522,7 @@ data class TerminalScreen(
                 if (screenBuffer.isEmpty()) {
                     Text(
                         text = stringResource(Res.string.terminal_initializing),
-                        color = Color.Gray,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
                         fontFamily = TerminalFontConfig.fontFamily,
                         fontSize = TerminalFontConfig.fontSize
                     )

--- a/mobile-vibe-terminal/src/commonMain/kotlin/tokyo/isseikuzumaki/vibeterminal/ui/theme/Color.kt
+++ b/mobile-vibe-terminal/src/commonMain/kotlin/tokyo/isseikuzumaki/vibeterminal/ui/theme/Color.kt
@@ -1,0 +1,61 @@
+package tokyo.isseikuzumaki.vibeterminal.ui.theme
+
+import androidx.compose.ui.graphics.Color
+
+/**
+ * Vibe Terminal M3 Dark Color Palette
+ *
+ * Design Principles:
+ * - Avoid pure black (#000000) for backgrounds to enable depth/elevation
+ * - Use softer green instead of harsh neon lime (#00FF00)
+ * - Consistent 8dp grid system for spacing
+ */
+
+// Background (deep charcoal, NOT pure black)
+val VtBackground = Color(0xFF121212)
+
+// Surface colors (slightly lighter for elevation hierarchy)
+val VtSurface = Color(0xFF1E1E1E)
+val VtSurfaceVariant = Color(0xFF252525)
+val VtSurfaceContainer = Color(0xFF1A1A1A)
+val VtSurfaceContainerHigh = Color(0xFF2A2A2A)
+
+// Primary (adjusted terminal green - softer and easier on eyes)
+val VtPrimary = Color(0xFF4CAF50)
+val VtPrimaryContainer = Color(0xFF1B5E20)
+val VtOnPrimary = Color(0xFF000000)
+val VtOnPrimaryContainer = Color(0xFFA5D6A7)
+
+// Secondary (muted teal for accents)
+val VtSecondary = Color(0xFF80CBC4)
+val VtSecondaryContainer = Color(0xFF00695C)
+val VtOnSecondary = Color(0xFF000000)
+val VtOnSecondaryContainer = Color(0xFFB2DFDB)
+
+// Tertiary (amber for warnings/highlights)
+val VtTertiary = Color(0xFFFFB74D)
+val VtTertiaryContainer = Color(0xFFE65100)
+val VtOnTertiary = Color(0xFF000000)
+val VtOnTertiaryContainer = Color(0xFFFFE0B2)
+
+// On Surface (text colors)
+val VtOnSurface = Color(0xFFE0E0E0)
+val VtOnSurfaceVariant = Color(0xFF9E9E9E)
+
+// Error
+val VtError = Color(0xFFCF6679)
+val VtErrorContainer = Color(0xFFB00020)
+val VtOnError = Color(0xFF000000)
+val VtOnErrorContainer = Color(0xFFFFDAD6)
+
+// Outline
+val VtOutline = Color(0xFF5C5C5C)
+val VtOutlineVariant = Color(0xFF3C3C3C)
+
+// Inverse
+val VtInverseSurface = Color(0xFFE0E0E0)
+val VtInverseOnSurface = Color(0xFF121212)
+val VtInversePrimary = Color(0xFF1B5E20)
+
+// Scrim
+val VtScrim = Color(0xFF000000)

--- a/mobile-vibe-terminal/src/commonMain/kotlin/tokyo/isseikuzumaki/vibeterminal/ui/theme/Shape.kt
+++ b/mobile-vibe-terminal/src/commonMain/kotlin/tokyo/isseikuzumaki/vibeterminal/ui/theme/Shape.kt
@@ -1,0 +1,21 @@
+package tokyo.isseikuzumaki.vibeterminal.ui.theme
+
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Shapes
+import androidx.compose.ui.unit.dp
+
+/**
+ * Vibe Terminal M3 Shape Definitions
+ *
+ * Following M3 guidelines:
+ * - Small: 8dp (buttons, chips)
+ * - Medium: 16dp (cards)
+ * - Large: 28dp (dialogs, FABs)
+ */
+val VibeTerminalShapes = Shapes(
+    extraSmall = RoundedCornerShape(4.dp),
+    small = RoundedCornerShape(8.dp),
+    medium = RoundedCornerShape(16.dp),
+    large = RoundedCornerShape(28.dp),
+    extraLarge = RoundedCornerShape(32.dp)
+)

--- a/mobile-vibe-terminal/src/commonMain/kotlin/tokyo/isseikuzumaki/vibeterminal/ui/theme/Theme.kt
+++ b/mobile-vibe-terminal/src/commonMain/kotlin/tokyo/isseikuzumaki/vibeterminal/ui/theme/Theme.kt
@@ -1,0 +1,81 @@
+package tokyo.isseikuzumaki.vibeterminal.ui.theme
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.runtime.Composable
+
+/**
+ * Vibe Terminal M3 Dark Color Scheme
+ *
+ * Designed for terminal applications with:
+ * - Deep charcoal backgrounds (no pure black)
+ * - Softer terminal green primary color
+ * - Proper elevation hierarchy via surface variants
+ */
+private val VibeTerminalDarkColorScheme = darkColorScheme(
+    // Primary
+    primary = VtPrimary,
+    onPrimary = VtOnPrimary,
+    primaryContainer = VtPrimaryContainer,
+    onPrimaryContainer = VtOnPrimaryContainer,
+
+    // Secondary
+    secondary = VtSecondary,
+    onSecondary = VtOnSecondary,
+    secondaryContainer = VtSecondaryContainer,
+    onSecondaryContainer = VtOnSecondaryContainer,
+
+    // Tertiary
+    tertiary = VtTertiary,
+    onTertiary = VtOnTertiary,
+    tertiaryContainer = VtTertiaryContainer,
+    onTertiaryContainer = VtOnTertiaryContainer,
+
+    // Background & Surface
+    background = VtBackground,
+    onBackground = VtOnSurface,
+    surface = VtSurface,
+    onSurface = VtOnSurface,
+    surfaceVariant = VtSurfaceVariant,
+    onSurfaceVariant = VtOnSurfaceVariant,
+    surfaceContainerLowest = VtBackground,
+    surfaceContainerLow = VtSurfaceContainer,
+    surfaceContainer = VtSurface,
+    surfaceContainerHigh = VtSurfaceContainerHigh,
+    surfaceContainerHighest = VtSurfaceContainerHigh,
+
+    // Error
+    error = VtError,
+    onError = VtOnError,
+    errorContainer = VtErrorContainer,
+    onErrorContainer = VtOnErrorContainer,
+
+    // Outline
+    outline = VtOutline,
+    outlineVariant = VtOutlineVariant,
+
+    // Inverse
+    inverseSurface = VtInverseSurface,
+    inverseOnSurface = VtInverseOnSurface,
+    inversePrimary = VtInversePrimary,
+
+    // Scrim
+    scrim = VtScrim
+)
+
+/**
+ * Vibe Terminal Theme
+ *
+ * Wraps the app content with M3 MaterialTheme using the Vibe Terminal color scheme.
+ * Apply this at the root of the app to enable consistent theming throughout.
+ */
+@Composable
+fun VibeTerminalTheme(
+    content: @Composable () -> Unit
+) {
+    MaterialTheme(
+        colorScheme = VibeTerminalDarkColorScheme,
+        shapes = VibeTerminalShapes,
+        content = content
+    )
+}


### PR DESCRIPTION
## Summary
- Vibe TerminalアプリのUIをMaterial Design 3 (M3) に準拠したモダンなデザインへ刷新
- 過度なコントラスト、詰まった余白、古いコンポーネントスタイルを解消
- 統一されたテーマシステムによる一貫性のあるデザイン

## Changes
### テーマシステム (新規)
- `Color.kt`: M3ダークカラーパレット (深いチャコールグレー背景、落ち着いた緑のプライマリ色)
- `Theme.kt`: `VibeTerminalTheme` composable
- `Shape.kt`: 角丸定義 (8dp/16dp/28dp)

### ConnectionListScreen
- TopAppBar/FABをテーマ色に統一
- カードをRow-basedレイアウトに変更 (左:ホスト情報、右:アクションアイコン)
- ダイアログに28dp角丸、スクロール対応、16dp余白を追加

### TerminalScreen
- TopAppBarをテーマ色に統一
- ステータスインジケーター(接続中/再接続中/エラー)をテーマ色に統一

### MacroInputPanel/MacroTabRow/MacroButton
- ハードコードされた色をMaterialTheme.colorSchemeに置換
- MacroButtonをOutlinedButton+スタジアム形状に変更

## Design Improvements
| Before | After |
|--------|-------|
| 純粋な黒(#000000)背景 | 深いチャコールグレー(#121212)で奥行きを表現 |
| ネオングリーン(#00FF00) | 落ち着いた緑(#4CAF50) |
| Column-basedカード | Row-basedカード (左:情報、右:アクション) |
| ハードコード色 | MaterialTheme.colorScheme |

## Test plan
- [x] 接続リスト画面の表示確認
- [x] 接続追加/編集ダイアログの表示確認
- [x] ターミナル画面のTopAppBar表示確認
- [x] マクロパネル(タブ、ボタン、トグル)の表示・操作確認
- [x] ダークテーマでの視認性確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)