### PR TITLE
feat: TopAppBarに接続追加ボタンを配置しFABを削除

### DIFF
--- a/mobile-vibe-terminal/src/commonMain/kotlin/tokyo/isseikuzumaki/vibeterminal/ui/screens/ConnectionListScreen.kt
+++ b/mobile-vibe-terminal/src/commonMain/kotlin/tokyo/isseikuzumaki/vibeterminal/ui/screens/ConnectionListScreen.kt
@@ -91,6 +91,15 @@ class ConnectionListScreen : Screen {
                             )
                         }
 
+                        // Add connection button
+                        IconButton(onClick = { screenModel.showAddDialog() }) {
+                            Icon(
+                                Icons.Default.Add,
+                                contentDescription = stringResource(Res.string.connection_list_add),
+                                tint = MaterialTheme.colorScheme.primary
+                            )
+                        }
+
                         // Settings menu
                         Box {
                             IconButton(onClick = { showSettingsMenu = true }) {
@@ -167,15 +176,6 @@ class ConnectionListScreen : Screen {
                         }
                     }
                 )
-            },
-            floatingActionButton = {
-                FloatingActionButton(
-                    onClick = { screenModel.showAddDialog() },
-                    containerColor = MaterialTheme.colorScheme.primary,
-                    contentColor = MaterialTheme.colorScheme.onPrimary
-                ) {
-                    Icon(Icons.Default.Add, stringResource(Res.string.connection_list_add))
-                }
             }
         ) { padding ->
             Column(


### PR DESCRIPTION
## Summary
- TopAppBarに接続追加ボタン(+アイコン)を追加
- FloatingActionButton(FAB)を削除してUIをシンプル化

## Changes
- `ConnectionListScreen.kt`
  - TopAppBarのactionsに`IconButton`を追加（設定ボタンの左隣）
  - `floatingActionButton`パラメータを削除

## Before / After
| Before | After |
|--------|-------|
| FABで接続追加 | TopAppBarの+ボタンで接続追加 |
| 画面右下にFAB | FABなし（シンプルなUI） |

## Test plan
- [x] TopAppBarの+ボタンをタップして接続追加ダイアログが表示されることを確認
- [x] FABが表示されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)