### PR TITLE
chore: remove unnecessary SYSTEM_ALERT_WINDOW permission and clean up…

### DIFF
--- a/mobile-vibe-terminal/src/androidMain/AndroidManifest.xml
+++ b/mobile-vibe-terminal/src/androidMain/AndroidManifest.xml
@@ -10,7 +10,6 @@
     <!-- Permissions for secondary display -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
-    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
 
     <application
         android:name=".VibeTerminalApp"

--- a/mobile-vibe-terminal/src/androidMain/kotlin/tokyo/isseikuzumaki/vibeterminal/platform/SecondaryDisplayLauncher.android.kt
+++ b/mobile-vibe-terminal/src/androidMain/kotlin/tokyo/isseikuzumaki/vibeterminal/platform/SecondaryDisplayLauncher.android.kt
@@ -2,9 +2,7 @@ package tokyo.isseikuzumaki.vibeterminal.platform
 
 import android.content.Context
 import android.content.Intent
-import android.net.Uri
 import android.os.Build
-import android.provider.Settings
 import androidx.core.content.ContextCompat
 import tokyo.isseikuzumaki.vibeterminal.service.TerminalService
 import tokyo.isseikuzumaki.vibeterminal.util.Logger
@@ -51,31 +49,7 @@ actual fun launchSecondaryDisplay(context: Any?) {
             return
         }
 
-        Logger.d("launchSecondaryDisplay: checking permission")
-
-        // Check if SYSTEM_ALERT_WINDOW permission is granted
-        if (!Settings.canDrawOverlays(context)) {
-            Logger.w("SYSTEM_ALERT_WINDOW permission not granted, requesting...")
-
-            // Open settings to request permission
-            val intent = Intent(
-                Settings.ACTION_MANAGE_OVERLAY_PERMISSION,
-                Uri.parse("package:${context.packageName}")
-            ).apply {
-                flags = Intent.FLAG_ACTIVITY_NEW_TASK
-            }
-
-            try {
-                context.startActivity(intent)
-                Logger.d("Opened overlay permission settings")
-            } catch (e: Exception) {
-                Logger.e(e, "Failed to open overlay permission settings")
-            }
-
-            return
-        }
-
-        Logger.d("Permission granted, starting TerminalService")
+        Logger.d("Starting TerminalService (permission check disabled for testing)")
 
         // Start TerminalService as foreground service
         try {

--- a/mobile-vibe-terminal/src/commonMain/kotlin/tokyo/isseikuzumaki/vibeterminal/ui/screens/ConnectionListScreen.kt
+++ b/mobile-vibe-terminal/src/commonMain/kotlin/tokyo/isseikuzumaki/vibeterminal/ui/screens/ConnectionListScreen.kt
@@ -1,14 +1,14 @@
 package tokyo.isseikuzumaki.vibeterminal.ui.screens
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
-import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Delete
@@ -27,19 +27,17 @@ import cafe.adriel.voyager.core.screen.Screen
 import cafe.adriel.voyager.koin.koinScreenModel
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
-import androidx.compose.runtime.LaunchedEffect
 import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.koinInject
+import puzzroom.mobile_vibe_terminal.generated.resources.*
 import tokyo.isseikuzumaki.vibeterminal.data.datastore.PreferencesHelper
 import tokyo.isseikuzumaki.vibeterminal.domain.model.ConnectionConfig
 import tokyo.isseikuzumaki.vibeterminal.domain.model.SavedConnection
 import tokyo.isseikuzumaki.vibeterminal.security.SshKeyInfoCommon
-import tokyo.isseikuzumaki.vibeterminal.viewmodel.ConnectionListScreenModel
-import tokyo.isseikuzumaki.vibeterminal.ui.components.StartUpCommandInput
 import tokyo.isseikuzumaki.vibeterminal.terminal.TerminalDisplayManager
-import androidx.compose.ui.unit.sp
-import org.jetbrains.compose.resources.stringResource
-import puzzroom.mobile_vibe_terminal.generated.resources.*
+import tokyo.isseikuzumaki.vibeterminal.ui.components.StartUpCommandInput
+import tokyo.isseikuzumaki.vibeterminal.viewmodel.ConnectionListScreenModel
 
 class ConnectionListScreen : Screen {
     @OptIn(ExperimentalMaterial3Api::class)
@@ -81,16 +79,6 @@ class ConnectionListScreen : Screen {
                         titleContentColor = MaterialTheme.colorScheme.primary
                     ),
                     actions = {
-                        // Display connection indicator (informational only)
-                        if (isDisplayConnected) {
-                            Text(
-                                text = stringResource(Res.string.connection_list_test_display),
-                                fontSize = 12.sp,
-                                color = MaterialTheme.colorScheme.primary,
-                                modifier = Modifier.padding(end = 16.dp)
-                            )
-                        }
-
                         // Add connection button
                         IconButton(onClick = { screenModel.showAddDialog() }) {
                             Icon(


### PR DESCRIPTION
This pull request primarily removes the requirement for the `SYSTEM_ALERT_WINDOW` permission and its associated runtime permission check when launching the secondary display on Android. Additionally, there are minor cleanups and import optimizations in the Compose UI screen code.

**Android permission and logic changes:**

* Removed the `SYSTEM_ALERT_WINDOW` permission from `AndroidManifest.xml`, so the app no longer requests this permission at install time.
* Eliminated all code related to checking and requesting the overlay permission (`SYSTEM_ALERT_WINDOW`) in `SecondaryDisplayLauncher.android.kt`, simplifying the logic for launching the secondary display.
* Removed unused imports related to overlay permission handling from `SecondaryDisplayLauncher.android.kt`.

**UI and code cleanup:**

* Cleaned up and reordered imports in `ConnectionListScreen.kt` for better readability and removed unused imports. [[1]](diffhunk://#diff-7b4e0c5bd4fdddf43f6babd258357cd2e0df050a26b4571a6c5d6ac215feeafaR3-R11) [[2]](diffhunk://#diff-7b4e0c5bd4fdddf43f6babd258357cd2e0df050a26b4571a6c5d6ac215feeafaL30-R40)
* Removed the display connection indicator UI from the top app bar in `ConnectionListScreen`, making the UI less cluttered.