### PR TITLE
refactor: use version catalog for Hyperion dependencies

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,6 +39,7 @@ ksp = "2.2.20-2.0.4"
 mina-sshd = "2.16.0"
 datastore = "1.2.0"
 timber = "5.0.1"
+hyperion = "0.9.38"
 
 [libraries]
 androidx-icons-core = { module = "androidx.compose.material.icons:material-icons-core", version.ref = "icons" }
@@ -109,6 +110,10 @@ datastore-preferences = { module = "androidx.datastore:datastore-preferences", v
 
 # Timber Logging
 timber = { module = "com.jakewharton.timber:timber", version.ref = "timber" }
+
+# Hyperion
+hyperion-core = { module = "com.willowtreeapps.hyperion:hyperion-core", version.ref = "hyperion" }
+hyperion-timber = { module = "com.willowtreeapps.hyperion:hyperion-timber", version.ref = "hyperion" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }

--- a/mobile-vibe-terminal/build.gradle.kts
+++ b/mobile-vibe-terminal/build.gradle.kts
@@ -184,8 +184,8 @@ android {
 
 dependencies {
     debugImplementation(compose.uiTooling)
-    debugImplementation("com.willowtreeapps.hyperion:hyperion-core:0.9.38")
-    debugImplementation("com.willowtreeapps.hyperion:hyperion-timber:0.9.38")
+    debugImplementation(libs.hyperion.core)
+    debugImplementation(libs.hyperion.timber)
 }
 
 abstract class NotifyApkPathTask : DefaultTask() {


### PR DESCRIPTION
Moved hardcoded Hyperion dependencies to the version catalog and verified they are still only used in debug builds.